### PR TITLE
Small fixes to ImportDiscourseDBjs

### DIFF
--- a/CommonSchemas/WorkflowsCommon.xsd
+++ b/CommonSchemas/WorkflowsCommon.xsd
@@ -47,6 +47,10 @@
 	<xs:restriction base="xs:string" />
 </xs:simpleType>
 
+<xs:simpleType name="DiscourseDbSelector" >
+  <xs:restriction base="xs:string" />
+</xs:simpleType>
+
 <xs:simpleType name="TetradGraphEditor" >
   <xs:restriction base="xs:string" />
 </xs:simpleType>

--- a/CommonSchemas/WorkflowsCommon.xsd
+++ b/CommonSchemas/WorkflowsCommon.xsd
@@ -47,10 +47,6 @@
 	<xs:restriction base="xs:string" />
 </xs:simpleType>
 
-<xs:simpleType name="DiscourseDbSelector" >
-  <xs:restriction base="xs:string" />
-</xs:simpleType>
-
 <xs:simpleType name="TetradGraphEditor" >
   <xs:restriction base="xs:string" />
 </xs:simpleType>

--- a/ImportDiscourseDBjs/build.xml
+++ b/ImportDiscourseDBjs/build.xml
@@ -88,6 +88,8 @@
             <arg value="${basedir}/test/" />
             <arg value="-toolDir" />
             <arg value="${basedir}/" />
+            <arg value="-userId" />  <!-- The source depends on this userId being present (this.getUserId()) -->
+            <arg value="mkomisin" />
             <arg value="-schemaFile" />
             <arg value="${basedir}/schemas/ImportDiscourseDBjs_v1_0.xsd" />
             <jvmarg value="-Xmx1048m"/>

--- a/ImportDiscourseDBjs/schemas/ImportDiscourseDBjs_v1_0.xsd
+++ b/ImportDiscourseDBjs/schemas/ImportDiscourseDBjs_v1_0.xsd
@@ -2,6 +2,9 @@
 
   <xs:include schemaLocation="../../CommonSchemas/WorkflowsCommon.xsd" />
 
+  <xs:simpleType name="DiscourseDbSelector" >
+  <xs:restriction base="xs:string" />
+  </xs:simpleType>
 
   <xs:complexType name="InFileList"/>
 
@@ -32,9 +35,7 @@
 
   <xs:complexType name="OptionsType">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-
       <xs:element type="DiscourseDbSelector" name="DiscourseDbSelector" id="DiscourseDbSelector" default="0" />
- 
     </xs:choice>
   </xs:complexType>
     

--- a/ImportDiscourseDBjs/schemas/ImportDiscourseDBjs_v1_0.xsd
+++ b/ImportDiscourseDBjs/schemas/ImportDiscourseDBjs_v1_0.xsd
@@ -52,7 +52,7 @@
         <xs:element name="connections" minOccurs="0" maxOccurs="1"  type="ConnectionType" />
         
         <xs:element name="outputs" type="OutputType" minOccurs="0" />
-        <xs:element name="options" minOccurs="0" />
+        <xs:element name="options" type="OptionsType" minOccurs="0" />
       </xs:all>
     </xs:complexType>
   </xs:element>

--- a/ImportDiscourseDBjs/source/edu/cmu/cs/lti/discoursedb/remote/ImportDiscourseDBjs.java
+++ b/ImportDiscourseDBjs/source/edu/cmu/cs/lti/discoursedb/remote/ImportDiscourseDBjs.java
@@ -37,7 +37,6 @@ public class ImportDiscourseDBjs extends AbstractComponent {
 	        }
 		} catch (Exception e) {
 			// TODO Auto-generated catch block
-			e.printStackTrace();
 			errorMessages.add("Error querying discoursedb as " + this.getUserId() + ":  " + e.getMessage());
 		}
 

--- a/ImportDiscourseDBjs/source/edu/cmu/cs/lti/discoursedb/remote/QueryProxy.java
+++ b/ImportDiscourseDBjs/source/edu/cmu/cs/lti/discoursedb/remote/QueryProxy.java
@@ -81,7 +81,6 @@ public class QueryProxy {
             keyStore.load(keyStoreStream, password.toCharArray());
             return keyStore;
         } catch (Exception e) {
-			e.printStackTrace();
 			throw(new IOException("Must have the " + path + " file in the classpath"));
 		}
     }
@@ -111,7 +110,6 @@ public class QueryProxy {
 		    		
 			} catch (IOException e) {
 				// TODO Auto-generated catch block
-				e.printStackTrace();
 				IOException oops = new IOException(help,e);
 				throw(oops);
 			}

--- a/ImportDiscourseDBjs/test/components/ImportDiscourseDBjs.xml
+++ b/ImportDiscourseDBjs/test/components/ImportDiscourseDBjs.xml
@@ -12,7 +12,6 @@
         </connection>
     </connections>
     <options>
-    <discourse_part>1491</discourse_part>
-    <authorized_email>nobody@nowhere.com</authorized_email>
+    <DiscourseDbSelector>{"startTime":null,"endTime":null,"id":7,"propName":"Xyz","propType":"query","propValue":"{\"database\":\"openfl\",\"rows\":{\"discourse_part\":[{\"dpid\":\"2\",\"name\":\"openfl/box2d\"}]}}"}</DiscourseDbSelector>
     </options>
 </component>


### PR DESCRIPTION
Note, this won't work without two files: discoursedb.query.properties, and cert.p12, which are sitting on Glacier.  They have passwords so can't be checked in here.  Somehow they need to be automatically installed without being placed on Github.

Also, two more files are needed, DiscourseDbSelector.html and customOptions.js.  I believe those are already added to SVN.