### PR TITLE
Remove stdout rootLogger from some components

### DIFF
--- a/CreateSession/log4j2.properties
+++ b/CreateSession/log4j2.properties
@@ -29,5 +29,4 @@ logger.cmupslc.name = edu.cmu.pslc
 logger.cmupslc.level = info
 
 rootLogger.level = debug
-rootLogger.appenderRef.stdout.ref = stdout
 rootLogger.appenderRef.R.ref = R

--- a/CurriculumPacing/log4j2.properties
+++ b/CurriculumPacing/log4j2.properties
@@ -29,5 +29,4 @@ logger.cmupslc.name = edu.cmu.pslc
 logger.cmupslc.level = info
 
 rootLogger.level = debug
-rootLogger.appenderRef.stdout.ref = stdout
 rootLogger.appenderRef.R.ref = R

--- a/EngagementMetrics/log4j2.properties
+++ b/EngagementMetrics/log4j2.properties
@@ -29,5 +29,4 @@ logger.cmupslc.name = edu.cmu.pslc
 logger.cmupslc.level = info
 
 rootLogger.level = debug
-rootLogger.appenderRef.stdout.ref = stdout
 rootLogger.appenderRef.R.ref = R

--- a/GamingDetector/log4j2.properties
+++ b/GamingDetector/log4j2.properties
@@ -29,5 +29,4 @@ logger.cmupslc.name = edu.cmu.pslc
 logger.cmupslc.level = info
 
 rootLogger.level = debug
-rootLogger.appenderRef.stdout.ref = stdout
 rootLogger.appenderRef.R.ref = R

--- a/KCExport/log4j2.properties
+++ b/KCExport/log4j2.properties
@@ -29,5 +29,4 @@ logger.cmupslc.name = edu.cmu.pslc
 logger.cmupslc.level = info
 
 rootLogger.level = debug
-rootLogger.appenderRef.stdout.ref = stdout
 rootLogger.appenderRef.R.ref = R

--- a/KCImport/log4j2.properties
+++ b/KCImport/log4j2.properties
@@ -29,5 +29,4 @@ logger.cmupslc.name = edu.cmu.pslc
 logger.cmupslc.level = info
 
 rootLogger.level = debug
-rootLogger.appenderRef.stdout.ref = stdout
 rootLogger.appenderRef.R.ref = R

--- a/KMeansClustering/log4j2.properties
+++ b/KMeansClustering/log4j2.properties
@@ -29,5 +29,4 @@ logger.cmupslc.name = edu.cmu.pslc
 logger.cmupslc.level = info
 
 rootLogger.level = debug
-rootLogger.appenderRef.stdout.ref = stdout
 rootLogger.appenderRef.R.ref = R

--- a/LearningRateAnalysis/log4j2.properties
+++ b/LearningRateAnalysis/log4j2.properties
@@ -29,5 +29,4 @@ logger.cmupslc.name = edu.cmu.pslc
 logger.cmupslc.level = info
 
 rootLogger.level = debug
-rootLogger.appenderRef.stdout.ref = stdout
 rootLogger.appenderRef.R.ref = R

--- a/PerformanceDifferenceAnalysis/log4j2.properties
+++ b/PerformanceDifferenceAnalysis/log4j2.properties
@@ -29,5 +29,4 @@ logger.cmupslc.name = edu.cmu.pslc
 logger.cmupslc.level = info
 
 rootLogger.level = debug
-rootLogger.appenderRef.stdout.ref = stdout
 rootLogger.appenderRef.R.ref = R

--- a/ProgressScoresConsolidatedReport/log4j2.properties
+++ b/ProgressScoresConsolidatedReport/log4j2.properties
@@ -29,5 +29,4 @@ logger.cmupslc.name = edu.cmu.pslc
 logger.cmupslc.level = info
 
 rootLogger.level = debug
-rootLogger.appenderRef.stdout.ref = stdout
 rootLogger.appenderRef.R.ref = R

--- a/RISE/log4j2.properties
+++ b/RISE/log4j2.properties
@@ -29,5 +29,4 @@ logger.cmupslc.name = edu.cmu.pslc
 logger.cmupslc.level = info
 
 rootLogger.level = debug
-rootLogger.appenderRef.stdout.ref = stdout
 rootLogger.appenderRef.R.ref = R

--- a/Templates/log4j2.properties
+++ b/Templates/log4j2.properties
@@ -29,5 +29,4 @@ logger.cmupslc.name = edu.cmu.pslc
 logger.cmupslc.level = info
 
 rootLogger.level = debug
-rootLogger.appenderRef.stdout.ref = stdout
 rootLogger.appenderRef.R.ref = R

--- a/description_png/log4j2.properties
+++ b/description_png/log4j2.properties
@@ -29,5 +29,4 @@ logger.cmupslc.name = edu.cmu.pslc
 logger.cmupslc.level = info
 
 rootLogger.level = debug
-rootLogger.appenderRef.stdout.ref = stdout
 rootLogger.appenderRef.R.ref = R

--- a/trendMAP_png/log4j2.properties
+++ b/trendMAP_png/log4j2.properties
@@ -29,5 +29,4 @@ logger.cmupslc.name = edu.cmu.pslc
 logger.cmupslc.level = info
 
 rootLogger.level = debug
-rootLogger.appenderRef.stdout.ref = stdout
 rootLogger.appenderRef.R.ref = R


### PR DESCRIPTION
Change should have gone into dev directly.
Some log4j2.properties were incorrectly defining a stdout rootLogger.